### PR TITLE
feat(dynamic-error-message): add support for dynamic error message

### DIFF
--- a/apimatic_core.gemspec
+++ b/apimatic_core.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'apimatic_core'
-  s.version = '0.1.1'
+  s.version = '0.2.0'
   s.summary = 'A library that contains apimatic-apimatic-core logic and utilities for consuming REST APIs using Python SDKs generated '\
               'by APIMatic.'
   s.description = 'The APIMatic Core libraries provide a stable runtime that powers all the functionality of SDKs.'\

--- a/apimatic_core.gemspec
+++ b/apimatic_core.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'apimatic_core'
-  s.version = '0.1.0'
+  s.version = '0.1.1'
   s.summary = 'A library that contains apimatic-apimatic-core logic and utilities for consuming REST APIs using Python SDKs generated '\
               'by APIMatic.'
   s.description = 'The APIMatic Core libraries provide a stable runtime that powers all the functionality of SDKs.'\
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency('nokogiri', '~> 1.10', '>=1.10.10')
   s.add_dependency('certifi', '~> 2018.1', '>= 2018.01.18')
   s.add_dependency('faraday-multipart', '~> 1.0')
+  s.add_dependency('json-pointer')
   s.add_development_dependency('faraday', '~> 2.0', '>= 2.0.1')
   s.add_development_dependency('minitest', '~> 5.14', '>= 5.14.1')
   s.add_development_dependency('minitest-proveit', '~> 1.0')

--- a/lib/apimatic-core/response_handler.rb
+++ b/lib/apimatic-core/response_handler.rb
@@ -44,13 +44,27 @@ module CoreLibrary
       self
     end
 
-    # Sets local_errors hash key value.
+    # Registers an entry with error message in the local errors hash.
     # @param [String] error_code The error code to check against.
-    # @param [String] description The reason for the exception.
+    # @param [String] error_message The reason for the exception.
     # @param [ApiException] exception_type The type of the exception to raise.
     # @return [ResponseHandler] An updated instance of ResponseHandler.
-    def local_error(error_code, description, exception_type)
-      @local_errors[error_code.to_s] = ErrorCase.new.description(description).exception_type(exception_type)
+    def local_error(error_code, error_message, exception_type)
+      @local_errors[error_code.to_s] = ErrorCase.new
+                                                .error_message(error_message)
+                                                .exception_type(exception_type)
+      self
+    end
+
+    # Registers an entry with error template in the local errors hash.
+    # @param [String] error_code The error code to check against.
+    # @param [String] error_message_template The reason template for the exception.
+    # @param [ApiException] exception_type The type of the exception to raise.
+    # @return [ResponseHandler] An updated instance of ResponseHandler.
+    def local_error_template(error_code, error_message_template, exception_type)
+      @local_errors[error_code.to_s] = ErrorCase.new
+                                                .error_message_template(error_message_template)
+                                                .exception_type(exception_type)
       self
     end
 
@@ -186,34 +200,16 @@ module CoreLibrary
     end
     # rubocop:enable Style/OptionalBooleanParameter
 
-    # Validates the response provided and throws an error from global_errors if it fails.
-    # @param response The received response.
-    # @param global_errors Global errors hash.
+    # Validates the response provided and throws an error against the configured status code.
+    # @param [HttpResponse] response The received response.
+    # @param [Hash] global_errors Global errors hash.
+    # @raise [ApiException] Throws the exception when the response contains errors.
     def validate(response, global_errors)
-      return unless response.status_code < 200 || response.status_code > 208
+      return unless response.status_code < 200 || response.status_code > 299
 
-      actual_status_code = response.status_code.to_s
+      validate_against_error_cases(response, @local_errors)
 
-      contains_local_errors = (!@local_errors.nil? and !@local_errors[actual_status_code].nil?)
-      if contains_local_errors
-        error_case = @local_errors[actual_status_code]
-        raise error_case.get_exception_type.new error_case.get_description, response
-      end
-
-      contains_local_default_error = (!@local_errors.nil? and !@local_errors['default'].nil?)
-      if contains_local_default_error
-        error_case = @local_errors['default']
-        raise error_case.get_exception_type.new error_case.get_description, response
-      end
-
-      contains_global_errors = (!global_errors.nil? and !global_errors[actual_status_code].nil?)
-      if contains_global_errors
-        error_case = global_errors[actual_status_code]
-        raise error_case.get_exception_type.new error_case.get_description, response
-      end
-
-      error_case = global_errors['default']
-      raise error_case.get_exception_type.new error_case.get_description, response unless error_case.nil?
+      validate_against_error_cases(response, global_errors)
     end
 
     # Applies xml deserializer to the response.
@@ -264,6 +260,32 @@ module CoreLibrary
       return @convertor.call(deserialized_value) unless @convertor.nil?
 
       deserialized_value
+    end
+
+    # Validates the response against the provided error cases hash, if matches, it raises the exception.
+    # @param [HttpResponse] response The received response.
+    # @param [Hash] error_cases The error cases hash.
+    # @raise [ApiException] Raises the APIException when configured error code matches.
+    def validate_against_error_cases(response, error_cases)
+      actual_status_code = response.status_code.to_s
+
+      # Handling error case when configured as explicit error code
+      error_case = error_cases[actual_status_code]
+      error_case&.raise_exception(response)
+
+      # Handling error case when configured as explicit error codes range
+      default_range_entry = error_cases&.filter do |error_code, _|
+        error_code.match?("^#{actual_status_code[0]}XX$")
+      end
+
+      default_range_error_case = default_range_entry&.map { |_, error_case_instance| error_case_instance }
+
+      default_range_error_case[0].raise_exception(response) unless
+        default_range_error_case.nil? || default_range_error_case.empty?
+
+      # Handling default error case if configured
+      default_error_case = error_cases['default']
+      default_error_case&.raise_exception(response)
     end
   end
 end

--- a/lib/apimatic-core/types/error_case.rb
+++ b/lib/apimatic-core/types/error_case.rb
@@ -2,22 +2,25 @@ module CoreLibrary
   # This data class represents the expected errors to be handled after the API call.
   class ErrorCase
     def initialize
-      @description = nil
+      @error_message = nil
+      @error_message_template = nil
       @exception_type = nil
     end
 
     # The setter for the description of the error message.
-    # @param [String] description The description of the error message.
+    # @param [String] error_message The error message.
     # @return [ErrorCase] An updated instance of ErrorCase.
-    def description(description)
-      @description = description
+    def error_message(error_message)
+      @error_message = error_message
       self
     end
 
-    # The getter for the description of the error message.
-    # @return [String] The description of the error message.
-    def get_description
-      @description
+    # The setter for the description of the error message.
+    # @param [String] error_message_template The error message template.
+    # @return [ErrorCase] An updated instance of ErrorCase.
+    def error_message_template(error_message_template)
+      @error_message_template = error_message_template
+      self
     end
 
     # The setter for the type of the exception to be thrown.
@@ -28,10 +31,48 @@ module CoreLibrary
       self
     end
 
-    # The getter for the type of the exception to be thrown.
-    # @return [Object] The type of the exception to be thrown.
-    def get_exception_type
-      @exception_type
+    # Getter for the error message for the exception case. This considers both error message
+    # and error template message. Error message template has the higher precedence over an error message.
+    # @param response The received http response.
+    # @return [String] The resolved exception message.
+    def get_error_message(response)
+      return _get_resolved_error_message_template(response) unless @error_message_template.nil?
+
+      @error_message
+    end
+
+    # Raises the exception for the current error case type.
+    # @param response The received response.
+    def raise_exception(response)
+      raise @exception_type.new get_error_message(response), response
+    end
+
+    # Updates all placeholders in the given message template with provided value.
+    # @param response The received http response.
+    # @return [String] The resolved template message.
+    def _get_resolved_error_message_template(response)
+      placeholders = @error_message_template.scan(/{\$.*?\}/)
+
+      status_code_placeholder = placeholders.select { |element| element == '{$statusCode}' }.uniq
+      header_placeholders = placeholders.select { |element| element.start_with?('{$response.header') }.uniq
+      body_placeholders = placeholders.select { |element| element.start_with?('{$response.body') }.uniq
+
+      # Handling response code placeholder
+      error_message_template = ApiHelper.resolve_template_placeholders(status_code_placeholder,
+                                                                       response.status_code.to_s,
+                                                                       @error_message_template)
+
+      # Handling response header placeholder
+      error_message_template = ApiHelper.resolve_template_placeholders(header_placeholders, response.headers,
+                                                                       error_message_template)
+
+      # Handling response body placeholder
+      response_payload = ApiHelper.json_deserialize(response.raw_body, true)
+      error_message_template = ApiHelper.resolve_template_placeholders_using_json_pointer(body_placeholders,
+                                                                                          response_payload,
+                                                                                          error_message_template)
+
+      error_message_template
     end
   end
 end

--- a/lib/apimatic_core.rb
+++ b/lib/apimatic_core.rb
@@ -3,6 +3,7 @@ require 'json'
 require 'certifi'
 require 'apimatic_core_interfaces'
 require 'cgi'
+require 'json-pointer'
 
 require_relative 'apimatic-core/request_builder'
 require_relative 'apimatic-core/response_handler'

--- a/test/test-helper/mock_helper.rb
+++ b/test/test-helper/mock_helper.rb
@@ -71,11 +71,24 @@ module TestComponent
 
     def self.get_global_errors
       {
-        'default' => ErrorCase.new.description('Invalid response.').exception_type(ApiException),
-        '412' => ErrorCase.new.description('Precondition Failed').exception_type(NestedModelException),
-        '450' => ErrorCase.new.description('caught global exception').exception_type(CustomErrorResponseException),
-        '452' => ErrorCase.new.description('global exception with string').exception_type(ExceptionWithStringException),
+        'default' => ErrorCase.new.error_message('Invalid response.').exception_type(ApiException),
+        '412' => ErrorCase.new.error_message('Precondition Failed').exception_type(NestedModelException),
+        '450' => ErrorCase.new.error_message('caught global exception').exception_type(CustomErrorResponseException),
+        '452' => ErrorCase.new.error_message('global exception with string').exception_type(ExceptionWithStringException),
+        '5XX' => ErrorCase.new.error_message('5XX global').exception_type(ApiException)
       }
+    end
+
+    def self.get_global_errors_with_template_message
+      { "400" => ErrorCase.new
+                        .error_message_template('error_code => {$statusCode}, header => {$response.header.accept}, body'\
+                                                ' => {$response.body#/ServerCode} - {$response.body#/ServerMessage}')
+                        .exception_type(GlobalTestException),
+        "412" => ErrorCase.new
+                          .error_message_template('global error message -> error_code => {$statusCode}, header => '\
+                                                  '{$response.header.accept}, body => {$response.body#/ServerCode} - '\
+                                                  '{$response.body#/ServerMessage} - {$response.body#/model/name}')
+                          .exception_type(NestedModelException)}
     end
 
     def self.create_logger(logger: nil)


### PR DESCRIPTION
This PR bears the support for the dynamic error message in error response which gets resolved at runtime in the response handler class. Other than the feature, this commit contains unit tests along with some refactoring of the existing `ErrorCase` and `ResponseHandler` classes.

closes #4