### PR TITLE
fix(ruby-core-lib): fix returning nil instead of empty request params

### DIFF
--- a/apimatic_core.gemspec
+++ b/apimatic_core.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'apimatic_core'
-  s.version = '0.3.0'
+  s.version = '0.3.1'
   s.summary = 'A library that contains apimatic-apimatic-core logic and utilities for consuming REST APIs using Python SDKs generated '\
               'by APIMatic.'
   s.description = 'The APIMatic Core libraries provide a stable runtime that powers all the functionality of SDKs.'\

--- a/lib/apimatic-core/request_builder.rb
+++ b/lib/apimatic-core/request_builder.rb
@@ -278,8 +278,6 @@ module CoreLibrary
       elsif _has_body_param && !_has_body_serializer
         return resolve_body_param
       end
-
-      {}
     end
 
     # Processes the part of a multipart request and assign appropriate part value and its content-type.

--- a/lib/apimatic-core/request_builder.rb
+++ b/lib/apimatic-core/request_builder.rb
@@ -266,23 +266,19 @@ module CoreLibrary
 
       if _has_xml_attributes
         return process_xml_parameters
-      end
-
-      if _has_form_params || _has_additional_form_params || _has_multipart_param
+      elsif _has_form_params || _has_additional_form_params || _has_multipart_param
         _form_params = @form_params
         _form_params.merge!(@form_params) if _has_form_params
         _form_params.merge!(@multipart_params) if _has_multipart_param
         _form_params.merge!(@additional_form_params) if _has_additional_form_params
         return ApiHelper.form_encode_parameters(_form_params, @array_serialization_format)
-      end
-
-      if _has_body_param && _has_body_serializer
+      elsif _has_body_param && _has_body_serializer
         return @body_serializer.call(resolve_body_param)
-      end
-      
-      if _has_body_param && !_has_body_serializer
+      elsif _has_body_param && !_has_body_serializer
         return resolve_body_param
       end
+
+      nil
     end
 
     # Processes the part of a multipart request and assign appropriate part value and its content-type.

--- a/lib/apimatic-core/request_builder.rb
+++ b/lib/apimatic-core/request_builder.rb
@@ -266,16 +266,21 @@ module CoreLibrary
 
       if _has_xml_attributes
         return process_xml_parameters
-      elsif _has_form_params || _has_additional_form_params || _has_multipart_param
+      end
+
+      if _has_form_params || _has_additional_form_params || _has_multipart_param
         _form_params = @form_params
         _form_params.merge!(@form_params) if _has_form_params
         _form_params.merge!(@multipart_params) if _has_multipart_param
         _form_params.merge!(@additional_form_params) if _has_additional_form_params
-        # TODO: add Array serialization format support while writing the POC
         return ApiHelper.form_encode_parameters(_form_params, @array_serialization_format)
-      elsif _has_body_param && _has_body_serializer
+      end
+
+      if _has_body_param && _has_body_serializer
         return @body_serializer.call(resolve_body_param)
-      elsif _has_body_param && !_has_body_serializer
+      end
+      
+      if _has_body_param && !_has_body_serializer
         return resolve_body_param
       end
     end

--- a/test/test-apimatic-core/request_builder_test.rb
+++ b/test/test-apimatic-core/request_builder_test.rb
@@ -115,6 +115,29 @@ class RequestBuilderTest < Minitest::Test
     assert(actual.parameters == "value")
   end
 
+  def test_no_body_request
+    actual = MockHelper.create_basic_request_builder
+                       .path('http://localhost/test/{key}')
+                       .http_method(HttpMethod::GET)
+                       .query_param(MockHelper.new_parameter("query", key: "key"))
+                       .template_param(MockHelper.new_parameter("template", key: "key"))
+                       .header_param(MockHelper.new_parameter("header", key: "key"))
+                       .build({})
+
+    assert_nil(actual.parameters)
+
+    actual = MockHelper.create_basic_request_builder
+                       .path('http://localhost/test/{key}')
+                       .http_method(HttpMethod::GET)
+                       .query_param(MockHelper.new_parameter("query", key: "key"))
+                       .template_param(MockHelper.new_parameter("template", key: "key"))
+                       .header_param(MockHelper.new_parameter("header", key: "key"))
+                       .form_param(MockHelper.new_parameter("form_param", key: "key"))
+                       .build({})
+
+    assert(actual.parameters["key"] == "form_param")
+  end
+
   def test_body_param_file
     file = File::open("README.md", "r")
 


### PR DESCRIPTION
## What
Fix returning nil instead of empty request params

## Why
This behavior causes Faraday urlEncode middleware to assign content-type to x-www-form-urlencoded.

closes #20

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [ ] My code follows the coding conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
