### PR TITLE
feat(rfc3339-timezone-info): add support for -ve timezone for rfc3339

### DIFF
--- a/apimatic_core.gemspec
+++ b/apimatic_core.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'apimatic_core'
-  s.version = '0.3.2'
+  s.version = '0.3.3'
   s.summary = 'A library that contains apimatic-apimatic-core logic and utilities for consuming REST APIs using Python SDKs generated '\
               'by APIMatic.'
   s.description = 'The APIMatic Core libraries provide a stable runtime that powers all the functionality of SDKs.'\

--- a/lib/apimatic-core/utilities/date_time_helper.rb
+++ b/lib/apimatic-core/utilities/date_time_helper.rb
@@ -116,7 +116,7 @@ module CoreLibrary
     # @return [DateTime] A DateTime object.
     def self.from_rfc3339(date_time)
       # missing timezone information
-      if date_time.match? /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[-+]\d{2}:\d{2})\z/
+      if date_time.match?(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[-+]\d{2}:\d{2})\z$/)
         DateTime.rfc3339(date_time)
       else
         DateTime.rfc3339("#{date_time}Z")

--- a/lib/apimatic-core/utilities/date_time_helper.rb
+++ b/lib/apimatic-core/utilities/date_time_helper.rb
@@ -116,7 +116,7 @@ module CoreLibrary
     # @return [DateTime] A DateTime object.
     def self.from_rfc3339(date_time)
       # missing timezone information
-      if date_time.end_with?('Z') || date_time.index('+')
+      if date_time.end_with?('Z') || date_time.index('+') || date_time.index('-')
         DateTime.rfc3339(date_time)
       else
         DateTime.rfc3339("#{date_time}Z")

--- a/lib/apimatic-core/utilities/date_time_helper.rb
+++ b/lib/apimatic-core/utilities/date_time_helper.rb
@@ -116,7 +116,7 @@ module CoreLibrary
     # @return [DateTime] A DateTime object.
     def self.from_rfc3339(date_time)
       # missing timezone information
-      if date_time.end_with?('Z') || date_time.index('+') || date_time.index('-')
+      if date_time.match? /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[-+]\d{2}:\d{2})\z/
         DateTime.rfc3339(date_time)
       else
         DateTime.rfc3339("#{date_time}Z")

--- a/test/test-apimatic-core/utilities/date_time_helper_test.rb
+++ b/test/test-apimatic-core/utilities/date_time_helper_test.rb
@@ -124,6 +124,15 @@ class DateTimeHelperTest < Minitest::Test
     assert_equal expected_dt, actual_dt
   end
 
+  def test_from_rfc3339_without_timezone
+    dt_in_rfc1123 = '2018-01-01T05:15:30'
+    actual_dt = DateTimeHelper.from_rfc3339(dt_in_rfc1123)
+    expected_dt = DateTime.parse(dt_in_rfc1123)
+
+    refute_nil actual_dt
+    assert_equal expected_dt, actual_dt
+  end
+
   def test_from_rfc3339_with_timezone
     dt_in_rfc1123 = '2018-01-01T05:15:30Z'
     actual_dt = DateTimeHelper.from_rfc3339(dt_in_rfc1123)

--- a/test/test-apimatic-core/utilities/date_time_helper_test.rb
+++ b/test/test-apimatic-core/utilities/date_time_helper_test.rb
@@ -124,10 +124,37 @@ class DateTimeHelperTest < Minitest::Test
     assert_equal expected_dt, actual_dt
   end
 
-  def test_from_rfc3339
+  def test_from_rfc3339_with_timezone
+    dt_in_rfc1123 = '2018-01-01T05:15:30Z'
+    actual_dt = DateTimeHelper.from_rfc3339(dt_in_rfc1123)
+    expected_dt = DateTime.parse(dt_in_rfc1123)
+
+    refute_nil actual_dt
+    assert_equal expected_dt, actual_dt
+  end
+
+  def test_from_rfc3339_zero_timezone_offset
     dt_in_rfc1123 = '2018-01-01T05:15:30+00:00'
     actual_dt = DateTimeHelper.from_rfc3339(dt_in_rfc1123)
-    expected_dt = Time.utc(2018, 1, 1, 5, 15, 30).to_datetime
+    expected_dt = DateTime.parse(dt_in_rfc1123)
+
+    refute_nil actual_dt
+    assert_equal expected_dt, actual_dt
+  end
+
+  def test_from_rfc3339_negative_timezone_offset
+    dt_in_rfc1123 = '2018-01-01T05:15:30-03:00'
+    actual_dt = DateTimeHelper.from_rfc3339(dt_in_rfc1123)
+    expected_dt = DateTime.parse(dt_in_rfc1123)
+
+    refute_nil actual_dt
+    assert_equal expected_dt, actual_dt
+  end
+
+  def test_from_rfc3339_positive_timezone_offset
+    dt_in_rfc1123 = '2018-01-01T05:15:30+03:00'
+    actual_dt = DateTimeHelper.from_rfc3339(dt_in_rfc1123)
+    expected_dt = DateTime.parse(dt_in_rfc1123)
 
     refute_nil actual_dt
     assert_equal expected_dt, actual_dt


### PR DESCRIPTION


## What
This PR adds support for datetime formats of RFC3339 standards such as `2021-10-01T00:00:00-01:00`. Earlier an exception is thrown during the deserialization of this kind of format.

## Why
To fix the deserialization of rfc3339 date-time standard

closes #25 

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
