### PR TITLE
fix(error-case ): fix deserialization exception in error template message

### DIFF
--- a/apimatic_core.gemspec
+++ b/apimatic_core.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'apimatic_core'
-  s.version = '0.3.3'
+  s.version = '0.3.4'
   s.summary = 'A library that contains apimatic-apimatic-core logic and utilities for consuming REST APIs using Python SDKs generated '\
               'by APIMatic.'
   s.description = 'The APIMatic Core libraries provide a stable runtime that powers all the functionality of SDKs.'\

--- a/lib/apimatic-core/types/error_case.rb
+++ b/lib/apimatic-core/types/error_case.rb
@@ -68,7 +68,12 @@ module CoreLibrary
                                                                        error_message_template)
 
       # Handling response body placeholder
-      response_payload = ApiHelper.json_deserialize(response.raw_body, true)
+      begin
+        response_payload = ApiHelper.json_deserialize(response.raw_body, true) unless response.raw_body.nil?
+      rescue TypeError
+        response_payload = nil
+      end
+
       error_message_template = ApiHelper.resolve_template_placeholders_using_json_pointer(body_placeholders,
                                                                                           response_payload,
                                                                                           error_message_template)

--- a/test/test-apimatic-core/response_handler_test.rb
+++ b/test/test-apimatic-core/response_handler_test.rb
@@ -188,6 +188,23 @@ class ResponseHandlerTest < Minitest::Test
                       'body =>  -  - '
     assert_equal expected_reason, exception.to_s
   end
+  
+  def test_error_template_message_with_null_payload
+    response_mock = MockHelper.create_response status_code: 415, headers: { 'accept': 'application/json' },
+                                               raw_body: nil
+    begin
+      @response_handler.local_error_template(415,
+                                             'error_code => {$statusCode}, header => '\
+                                              '{$response.header.accept}, body => {$response.body}', ApiException)
+                       .handle(response_mock, MockHelper.get_global_errors_with_template_message, TestComponent)
+    rescue => exception
+      assert_instance_of ApiException, exception
+    end
+    refute_nil(exception)
+    expected_reason = 'error_code => 415, header => application/json, '\
+                      'body => '
+    assert_equal expected_reason, exception.to_s
+  end
 
   def test_global_error_template_message
     response_body_mock = '{"ServerCode": 5001, "ServerMessage": "Test message from server", "model": '\


### PR DESCRIPTION
fix(error-case ): fix deserialization exception in **_get_resolved_error_message_template**
closes #27

## What
Handle deserialization exception in error template message

## Why
response_body placeholder should be replaced with a empty value incase of any unsuccessful deserialized response
## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [ ] My code follows the coding conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
