### PR TITLE
fix(dynamic-messages-template): fallback to raw response body

### DIFF
--- a/lib/apimatic-core/types/error_case.rb
+++ b/lib/apimatic-core/types/error_case.rb
@@ -71,7 +71,8 @@ module CoreLibrary
       begin
         response_payload = ApiHelper.json_deserialize(response.raw_body, true) unless response.raw_body.nil?
       rescue TypeError
-        response_payload = nil
+        # This statement execution means the received response body is not a JSON but a simple string
+        response_payload = response.raw_body
       end
 
       error_message_template = ApiHelper.resolve_template_placeholders_using_json_pointer(body_placeholders,

--- a/test/test-apimatic-core/response_handler_test.rb
+++ b/test/test-apimatic-core/response_handler_test.rb
@@ -206,6 +206,40 @@ class ResponseHandlerTest < Minitest::Test
     assert_equal expected_reason, exception.to_s
   end
 
+  def test_error_template_message_with_simple_payload
+    response_mock = MockHelper.create_response status_code: 415, headers: { 'accept': 'application/json' },
+                                               raw_body: 'Unexpected response'
+    begin
+      @response_handler.local_error_template(415,
+                                             'error_code => {$statusCode}, header => '\
+                                              '{$response.header.accept}, body => {$response.body}', ApiException)
+                       .handle(response_mock, MockHelper.get_global_errors_with_template_message, TestComponent)
+    rescue => exception
+      assert_instance_of ApiException, exception
+    end
+    refute_nil(exception)
+    expected_reason = 'error_code => 415, header => application/json, '\
+                      'body => Unexpected response'
+    assert_equal expected_reason, exception.to_s
+  end
+
+  def test_error_template_message_with_json_payload
+    response_mock = MockHelper.create_response status_code: 415, headers: { 'accept': 'application/json' },
+                                               raw_body: '{ "property": "Unexpected response" }'
+    begin
+      @response_handler.local_error_template(415,
+                                             'error_code => {$statusCode}, header => '\
+                                              '{$response.header.accept}, body => {$response.body}', ApiException)
+                       .handle(response_mock, MockHelper.get_global_errors_with_template_message, TestComponent)
+    rescue => exception
+      assert_instance_of ApiException, exception
+    end
+    refute_nil(exception)
+    expected_reason = 'error_code => 415, header => application/json, '\
+                      'body => {"property":"Unexpected response"}'
+    assert_equal expected_reason, exception.to_s
+  end
+
   def test_global_error_template_message
     response_body_mock = '{"ServerCode": 5001, "ServerMessage": "Test message from server", "model": '\
                          '{ "field": "Test field", "name": "Test name", "address": "Test address"}}'


### PR DESCRIPTION

## What
This PR improves the fix made for dynamic error messages template through PR #28, it targets the case when the raw body is not able to deserialize because the response was not a JSON. In that case, the fallback is set to the raw response because we need to cover `$response.body` placeholder at the least.

## Why
To fix a possible bug in case of a non-JSON response body in the dynamic error messages template.

closes #27 

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
