### PR TITLE
fix(validation-utility): validation for model value hash

### DIFF
--- a/apimatic_core.gemspec
+++ b/apimatic_core.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'apimatic_core'
-  s.version = '0.3.5'
+  s.version = '0.3.6'
   s.summary = 'A library that contains apimatic-apimatic-core logic and utilities for consuming REST APIs using Python SDKs generated '\
               'by APIMatic.'
   s.description = 'The APIMatic Core libraries provide a stable runtime that powers all the functionality of SDKs.'\

--- a/lib/apimatic-core/utilities/api_helper.rb
+++ b/lib/apimatic-core/utilities/api_helper.rb
@@ -267,13 +267,14 @@ module CoreLibrary
     #   structure satisfy the type condition, false otherwise.
     def self.valid_type?(value, type_callable, is_model_hash: false, is_inner_model_hash: false)
       if value.is_a?(Array)
-        value.all? do |item| valid_type?(item, type_callable,
-                                         is_model_hash: is_model_hash,
-                                         is_inner_model_hash: is_inner_model_hash)
+        value.all? do |item|
+          valid_type?(item, type_callable,
+                      is_model_hash: is_model_hash,
+                      is_inner_model_hash: is_inner_model_hash)
         end
       elsif value.is_a?(Hash) && (!is_model_hash || is_inner_model_hash)
-        value.values.all? do |item| valid_type?(item, type_callable,
-                                                is_model_hash: is_model_hash)
+        value.values.all? do |item|
+          valid_type?(item, type_callable, is_model_hash: is_model_hash)
         end
       else
         !value.nil? && type_callable.call(value)

--- a/lib/apimatic-core/utilities/api_helper.rb
+++ b/lib/apimatic-core/utilities/api_helper.rb
@@ -261,13 +261,14 @@ module CoreLibrary
     # Checks if a value or all values in a nested structure satisfy a given type condition.
     # @param [Object] value The value or nested structure to be checked.
     # @param [Proc] type_callable A callable object that defines the type condition.
+    # @param [Boolean] is_model_hash A flag to identify the provided value is a model value hash.
     # @return [Boolean] Returns true if the value or all values in the
     #   structure satisfy the type condition, false otherwise.
-    def self.valid_type?(value, type_callable)
+    def self.valid_type?(value, type_callable, is_model_hash = false)
       if value.is_a?(Array)
-        value.all? { |item| valid_type?(item, type_callable) }
-      elsif value.is_a?(Hash)
-        value.values.all? { |item| valid_type?(item, type_callable) }
+        value.all? { |item| valid_type?(item, type_callable, is_model_hash) }
+      elsif value.is_a?(Hash) and not is_model_hash
+        value.values.all? { |item| valid_type?(item, type_callable, is_model_hash) }
       else
         !value.nil? && type_callable.call(value)
       end

--- a/lib/apimatic-core/utilities/api_helper.rb
+++ b/lib/apimatic-core/utilities/api_helper.rb
@@ -262,13 +262,19 @@ module CoreLibrary
     # @param [Object] value The value or nested structure to be checked.
     # @param [Proc] type_callable A callable object that defines the type condition.
     # @param [Boolean] is_model_hash A flag to identify the provided value is a model value hash.
+    # @param [Boolean] is_inner_model_hash A flag to identify the provided value is a hash of model value hash.
     # @return [Boolean] Returns true if the value or all values in the
     #   structure satisfy the type condition, false otherwise.
-    def self.valid_type?(value, type_callable, is_model_hash = false)
+    def self.valid_type?(value, type_callable, is_model_hash: false, is_inner_model_hash: false)
       if value.is_a?(Array)
-        value.all? { |item| valid_type?(item, type_callable, is_model_hash) }
-      elsif value.is_a?(Hash) && !is_model_hash
-        value.values.all? { |item| valid_type?(item, type_callable, is_model_hash) }
+        value.all? do |item| valid_type?(item, type_callable,
+                                         is_model_hash: is_model_hash,
+                                         is_inner_model_hash: is_inner_model_hash)
+        end
+      elsif value.is_a?(Hash) && (!is_model_hash || is_inner_model_hash)
+        value.values.all? do |item| valid_type?(item, type_callable,
+                                                is_model_hash: is_model_hash)
+        end
       else
         !value.nil? && type_callable.call(value)
       end

--- a/lib/apimatic-core/utilities/api_helper.rb
+++ b/lib/apimatic-core/utilities/api_helper.rb
@@ -267,7 +267,7 @@ module CoreLibrary
     def self.valid_type?(value, type_callable, is_model_hash = false)
       if value.is_a?(Array)
         value.all? { |item| valid_type?(item, type_callable, is_model_hash) }
-      elsif value.is_a?(Hash) and not is_model_hash
+      elsif value.is_a?(Hash) && !is_model_hash
         value.values.all? { |item| valid_type?(item, type_callable, is_model_hash) }
       else
         !value.nil? && type_callable.call(value)

--- a/test/test-apimatic-core/utilities/api_helper_test.rb
+++ b/test/test-apimatic-core/utilities/api_helper_test.rb
@@ -473,6 +473,20 @@ class ApiHelperTest < Minitest::Test
     assert ApiHelper.valid_type?([1, 2, 3], ->(value) { value.instance_of? Integer })
   end
 
+  def test_valid_type_model
+    _evening_json = '{"startsAt": "15:30", "endsAt": "20:30", "offerDinner": false, "sessionType": "Evening"}'
+    deserialized_evening = ApiHelper.json_deserialize(_evening_json)
+    assert ApiHelper.valid_type?(deserialized_evening,
+      ->(value) { TestComponent::Evening.validate(value) }, true)
+  end
+
+  def test_valid_type_model_array
+    _array_of_evening_json = '[{"startsAt": "15:30", "endsAt": "20:30", "offerDinner": false, "sessionType": "Evening"}, {"startsAt": "15:30", "endsAt": "20:30", "offerDinner": false, "sessionType": "Evening"}]'
+    deserialized_array_of_evening = ApiHelper.json_deserialize(_array_of_evening_json)
+    assert ApiHelper.valid_type?(deserialized_array_of_evening,
+      ->(value) { TestComponent::Evening.validate(value) }, true)
+  end
+
   def test_valid_type_hash
     assert ApiHelper.valid_type?(
       {

--- a/test/test-apimatic-core/utilities/api_helper_test.rb
+++ b/test/test-apimatic-core/utilities/api_helper_test.rb
@@ -477,14 +477,48 @@ class ApiHelperTest < Minitest::Test
     _evening_json = '{"startsAt": "15:30", "endsAt": "20:30", "offerDinner": false, "sessionType": "Evening"}'
     deserialized_evening = ApiHelper.json_deserialize(_evening_json)
     assert ApiHelper.valid_type?(deserialized_evening,
-      ->(value) { TestComponent::Evening.validate(value) }, true)
+                                 ->(value) { TestComponent::Evening.validate(value) },
+                                 is_model_hash: true)
+  end
+
+  def test_invalid_type_model
+    _evening_json = '{"startsAt": "15:30", "offerDinner": false, "sessionType": "Evening"}'
+    deserialized_evening = ApiHelper.json_deserialize(_evening_json)
+    assert ApiHelper.valid_type?(deserialized_evening,
+                                 ->(value) { TestComponent::Evening.validate(value) },
+                                 is_model_hash: true) == false
   end
 
   def test_valid_type_model_array
     _array_of_evening_json = '[{"startsAt": "15:30", "endsAt": "20:30", "offerDinner": false, "sessionType": "Evening"}, {"startsAt": "15:30", "endsAt": "20:30", "offerDinner": false, "sessionType": "Evening"}]'
     deserialized_array_of_evening = ApiHelper.json_deserialize(_array_of_evening_json)
     assert ApiHelper.valid_type?(deserialized_array_of_evening,
-      ->(value) { TestComponent::Evening.validate(value) }, true)
+                                 ->(value) { TestComponent::Evening.validate(value) },
+                                 is_model_hash: true)
+  end
+
+  def test_valid_type_model_map
+    _map_of_evening_json = '{"item1" : {"startsAt": "15:30", "endsAt": "20:30", "offerDinner": false, "sessionType": "Evening"}, "item2": {"startsAt": "15:30", "endsAt": "20:30", "offerDinner": false, "sessionType": "Evening"}}'
+    deserialized_map_of_evening = ApiHelper.json_deserialize(_map_of_evening_json)
+    assert ApiHelper.valid_type?(deserialized_map_of_evening,
+                                 ->(value) { TestComponent::Evening.validate(value) },
+                                 is_model_hash: true, is_inner_model_hash: true)
+  end
+
+  def test_valid_type_model_map_of_array
+    _map_of_array_of_evening_json = '{"item1" : [{"startsAt": "15:30", "endsAt": "20:30", "offerDinner": false, "sessionType": "Evening"}, {"startsAt": "15:30", "endsAt": "20:30", "offerDinner": false, "sessionType": "Evening"}], "item2": [{"startsAt": "15:30", "endsAt": "20:30", "offerDinner": false, "sessionType": "Evening"}, {"startsAt": "15:30", "endsAt": "20:30", "offerDinner": false, "sessionType": "Evening"}]}'
+    deserialized_map_of_array_of_evening = ApiHelper.json_deserialize(_map_of_array_of_evening_json)
+    assert ApiHelper.valid_type?(deserialized_map_of_array_of_evening,
+                                 ->(value) { TestComponent::Evening.validate(value) },
+                                 is_model_hash: true, is_inner_model_hash: true)
+  end
+
+  def test_valid_type_model_array_of_map
+    _array_of_map_of_evening_json = '[{"item1" : {"startsAt": "15:30", "endsAt": "20:30", "offerDinner": false, "sessionType": "Evening"}, "item2": {"startsAt": "15:30", "endsAt": "20:30", "offerDinner": false, "sessionType": "Evening"}}, {"item1" : {"startsAt": "15:30", "endsAt": "20:30", "offerDinner": false, "sessionType": "Evening"}, "item2": {"startsAt": "15:30", "endsAt": "20:30", "offerDinner": false, "sessionType": "Evening"}}]'
+    deserialized_array_of_map_of_evening = ApiHelper.json_deserialize(_array_of_map_of_evening_json)
+    assert ApiHelper.valid_type?(deserialized_array_of_map_of_evening,
+                                 ->(value) { TestComponent::Evening.validate(value) },
+                                 is_model_hash: true, is_inner_model_hash: true)
   end
 
   def test_valid_type_hash


### PR DESCRIPTION

## What
This PR fixes the validation of a hash that contains a simple model value as the deserialized model is treated as a hash. This hash was conflicting with the hash of some primitive or non-primitive types.

## Why
 - To fix the validation bug for the model value hash, used for OAF model properties validation

Closes #34 
## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
