### PR TITLE
feat(auth): add handling for oauth token skew time

### DIFF
--- a/apimatic_core.gemspec
+++ b/apimatic_core.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'apimatic_core'
-  s.version = '0.3.7'
+  s.version = '0.3.8'
   s.summary = 'A library that contains apimatic-apimatic-core logic and utilities for consuming REST APIs using Python SDKs generated '\
               'by APIMatic.'
   s.description = 'The APIMatic Core libraries provide a stable runtime that powers all the functionality of SDKs.'\

--- a/lib/apimatic-core/utilities/auth_helper.rb
+++ b/lib/apimatic-core/utilities/auth_helper.rb
@@ -16,6 +16,7 @@ module CoreLibrary
 
     # Checks if OAuth token has expired.
     # @param [int] token_expiry The expiring of a token.
+    # @param [int|Optional] clock_skew_time A buffer to the calculated expiry.
     # @return [Boolean] true if token has expired, false otherwise.
     def self.token_expired?(token_expiry, clock_skew_time = nil)
       raise ArgumentError, 'Token expiry can not be nil.' if token_expiry.nil?

--- a/lib/apimatic-core/utilities/auth_helper.rb
+++ b/lib/apimatic-core/utilities/auth_helper.rb
@@ -17,9 +17,10 @@ module CoreLibrary
     # Checks if OAuth token has expired.
     # @param [int] token_expiry The expiring of a token.
     # @return [Boolean] true if token has expired, false otherwise.
-    def self.token_expired?(token_expiry)
+    def self.token_expired?(token_expiry, clock_skew_time = nil)
       raise ArgumentError, 'Token expiry can not be nil.' if token_expiry.nil?
 
+      token_expiry -= clock_skew_time unless clock_skew_time.nil?
       token_expiry < Time.now.utc.to_i
     end
 

--- a/test/test-apimatic-core/utilities/auth_helper_test.rb
+++ b/test/test-apimatic-core/utilities/auth_helper_test.rb
@@ -77,6 +77,15 @@ class AuthHelperTest < Minitest::Test
     assert_equal expected_value, actual_value
   end
 
+  def test_token_not_expired_with_negative_clock_skew
+    token_expiry = Time.now().utc.to_i + 3600
+    actual_value = AuthHelper.token_expired?(token_expiry, -3600)
+    expected_value = false
+
+    refute_nil actual_value
+    assert_equal expected_value, actual_value
+  end
+
   def test_get_token_expiry
     current_timestamp = Time.now().utc.to_i
     expires_in = 3600

--- a/test/test-apimatic-core/utilities/auth_helper_test.rb
+++ b/test/test-apimatic-core/utilities/auth_helper_test.rb
@@ -52,6 +52,31 @@ class AuthHelperTest < Minitest::Test
     assert_equal expected_value, actual_value
   end
 
+  def test_token_is_expired_with_clock_skew
+    token_expiry = Time.now().utc.to_i + 3600
+    actual_value = AuthHelper.token_expired?(token_expiry, 7200)
+    expected_value = true
+
+    refute_nil actual_value
+    assert_equal expected_value, actual_value
+  end
+
+  def test_token_is_not_expired_with_clock_skew
+    token_expiry = Time.now().utc.to_i + 3600
+    actual_value = AuthHelper.token_expired?(token_expiry, 1440)
+    expected_value = false
+
+    refute_nil actual_value
+    assert_equal expected_value, actual_value
+
+    token_expiry = Time.now().utc.to_i + 3600
+    actual_value = AuthHelper.token_expired?(token_expiry, 3600)
+    expected_value = false
+
+    refute_nil actual_value
+    assert_equal expected_value, actual_value
+  end
+
   def test_get_token_expiry
     current_timestamp = Time.now().utc.to_i
     expires_in = 3600


### PR DESCRIPTION
## What
This PR updates the `is_token_expired` utility method to minimize the impact of clock skew between client and server during OAuth token validation.


## Why
1. Honors provided skew buffer.
3. Accounts for round-trip time for a more accurate expiry calculation. Improves token validation reliability and reduces unnecessary token refreshes.

Closes #38 

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [ ] My code follows the coding conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
