### PR TITLE
fix(logging): effect on request headers due to masking headers flow

### DIFF
--- a/lib/apimatic-core/logger/sdk_logger.rb
+++ b/lib/apimatic-core/logger/sdk_logger.rb
@@ -14,10 +14,10 @@ module CoreLibrary
       url = @request_logging_config.include_query_in_path ? request.query_url : request.query_url.split('?').first
 
       @logger.log(@log_level, "Request {#{METHOD}} {#{URL}} {#{CONTENT_TYPE_HEADER}}", {
-                    METHOD => request.http_method,
-                    URL => url,
-                    CONTENT_TYPE_HEADER => content_type_header
-                  })
+        METHOD => request.http_method,
+        URL => url,
+        CONTENT_TYPE_HEADER => content_type_header
+      })
 
       apply_log_request_options(request)
     end
@@ -27,10 +27,10 @@ module CoreLibrary
       content_length_header = LoggerHelper.get_content_length(response.headers)
 
       @logger.log(@log_level, "Response {#{STATUS_CODE}} {#{CONTENT_LENGTH_HEADER}} {#{CONTENT_TYPE_HEADER}}", {
-                    STATUS_CODE => response.status_code,
-                    CONTENT_LENGTH_HEADER => content_length_header,
-                    CONTENT_TYPE_HEADER => content_type_header
-                  })
+        STATUS_CODE => response.status_code,
+        CONTENT_LENGTH_HEADER => content_length_header,
+        CONTENT_TYPE_HEADER => content_type_header
+      })
 
       apply_log_response_options(response)
     end
@@ -40,39 +40,41 @@ module CoreLibrary
     def apply_log_request_options(request)
       headers_to_log = LoggerHelper.extract_headers_to_log(
         @request_logging_config,
+        @mask_sensitive_headers,
         request.headers
       )
 
       if @request_logging_config.log_headers
         @logger.log(@log_level, 'Request headers {headers}', {
-                      headers: headers_to_log
-                    })
+          headers: headers_to_log
+        })
       end
 
       return unless @request_logging_config.log_body
 
       @logger.log(@log_level, 'Request body {body}', {
-                    body: request.parameters
-                  })
+        body: request.parameters
+      })
     end
 
     def apply_log_response_options(response)
       headers_to_log = LoggerHelper.extract_headers_to_log(
         @response_logging_config,
+        @mask_sensitive_headers,
         response.headers
       )
 
       if @response_logging_config.log_headers
         @logger.log(@log_level, 'Response headers {headers}', {
-                      headers: headers_to_log
-                    })
+          headers: headers_to_log
+        })
       end
 
       return unless @response_logging_config.log_body
 
       @logger.log(@log_level, 'Response body {body}', {
-                    body: response.raw_body
-                  })
+        body: response.raw_body
+      })
     end
   end
 end

--- a/lib/apimatic-core/logger/sdk_logger.rb
+++ b/lib/apimatic-core/logger/sdk_logger.rb
@@ -13,11 +13,12 @@ module CoreLibrary
       content_type_header = LoggerHelper.get_content_type(request.headers)
       url = @request_logging_config.include_query_in_path ? request.query_url : request.query_url.split('?').first
 
-      @logger.log(@log_level, "Request {#{METHOD}} {#{URL}} {#{CONTENT_TYPE_HEADER}}", {
-        METHOD => request.http_method,
-        URL => url,
-        CONTENT_TYPE_HEADER => content_type_header
-      })
+      @logger.log(@log_level, "Request {#{METHOD}} {#{URL}} {#{CONTENT_TYPE_HEADER}}",
+                  {
+                    METHOD => request.http_method,
+                    URL => url,
+                    CONTENT_TYPE_HEADER => content_type_header
+                  })
 
       apply_log_request_options(request)
     end
@@ -26,11 +27,12 @@ module CoreLibrary
       content_type_header = LoggerHelper.get_content_type(response.headers)
       content_length_header = LoggerHelper.get_content_length(response.headers)
 
-      @logger.log(@log_level, "Response {#{STATUS_CODE}} {#{CONTENT_LENGTH_HEADER}} {#{CONTENT_TYPE_HEADER}}", {
-        STATUS_CODE => response.status_code,
-        CONTENT_LENGTH_HEADER => content_length_header,
-        CONTENT_TYPE_HEADER => content_type_header
-      })
+      @logger.log(@log_level, "Response {#{STATUS_CODE}} {#{CONTENT_LENGTH_HEADER}} {#{CONTENT_TYPE_HEADER}}",
+                  {
+                    STATUS_CODE => response.status_code,
+                    CONTENT_LENGTH_HEADER => content_length_header,
+                    CONTENT_TYPE_HEADER => content_type_header
+                  })
 
       apply_log_response_options(response)
     end
@@ -45,16 +47,14 @@ module CoreLibrary
       )
 
       if @request_logging_config.log_headers
-        @logger.log(@log_level, 'Request headers {headers}', {
-          headers: headers_to_log
-        })
+        @logger.log(@log_level, 'Request headers {headers}',
+                    { headers: headers_to_log })
       end
 
       return unless @request_logging_config.log_body
 
-      @logger.log(@log_level, 'Request body {body}', {
-        body: request.parameters
-      })
+      @logger.log(@log_level, 'Request body {body}',
+                  { body: request.parameters })
     end
 
     def apply_log_response_options(response)
@@ -65,16 +65,14 @@ module CoreLibrary
       )
 
       if @response_logging_config.log_headers
-        @logger.log(@log_level, 'Response headers {headers}', {
-          headers: headers_to_log
-        })
+        @logger.log(@log_level, 'Response headers {headers}',
+                    { headers: headers_to_log })
       end
 
       return unless @response_logging_config.log_body
 
-      @logger.log(@log_level, 'Response body {body}', {
-        body: response.raw_body
-      })
+      @logger.log(@log_level, 'Response body {body}',
+                  { body: response.raw_body })
     end
   end
 end

--- a/lib/apimatic-core/utilities/constants.rb
+++ b/lib/apimatic-core/utilities/constants.rb
@@ -4,4 +4,5 @@ module CoreLibrary
   METHOD = 'method'.freeze
   URL = 'url'.freeze
   STATUS_CODE = 'status_code'.freeze
+  REDACTED = '**Redacted**'.freeze
 end

--- a/lib/apimatic-core/utilities/logger_helper.rb
+++ b/lib/apimatic-core/utilities/logger_helper.rb
@@ -79,7 +79,7 @@ module CoreLibrary
       name_downcase = name.downcase
 
       NON_SENSITIVE_HEADERS.include?(name_downcase) || headers_to_unmask.include?(name_downcase) ?
-        value : '**Redacted**'
+        value : REDACTED
     end
   end
 end

--- a/lib/apimatic-core/utilities/logger_helper.rb
+++ b/lib/apimatic-core/utilities/logger_helper.rb
@@ -63,7 +63,8 @@ module CoreLibrary
 
     def self.apply_masking_to_sensitive_headers(headers, mask_sensitive_headers, headers_to_unmask)
       return headers unless mask_sensitive_headers
-      return headers unless !headers.nil?
+      return headers if headers.nil?
+
       masked_headers = {}
       headers.each do |key, val|
         masked_headers[key] = mask_if_sensitive_header(key, val, headers_to_unmask)

--- a/test/test-apimatic-core/logger/sdk_logger_test.rb
+++ b/test/test-apimatic-core/logger/sdk_logger_test.rb
@@ -126,7 +126,7 @@ class SdkLoggerTest < Minitest::Test
       @basic_request_log,
       'info: Request headers {"authorization"=>"**Redacted**", "content-length"=>"449", "content-type"=>"application/json"}',
     ]
-     
+
     logger = TestLogger.new
     logger_config = MockHelper.create_logging_configuration(
       logger: logger,
@@ -138,12 +138,17 @@ class SdkLoggerTest < Minitest::Test
     sdk_logger = SdkLogger.new(logger_config)
     sdk_logger.log_request(@request)
     logged_messages = logger.logged_messages
-
     i = 0
     expected_logs.each do |msg|
       assert_includes(msg, logged_messages[i])
       i += 1
     end
+    expected_request_headers = {
+      'authorization' => 'Bearer EAAAEFZ2r-rqsEBBB0s2rh210e18mspf4dzga',
+      CONTENT_LENGTH_HEADER => '449',
+      CONTENT_TYPE_HEADER => JSON_CONTENT_TYPE
+    }
+    assert_equal(expected_request_headers, @request.headers)
   end
   def test_log_response_body
     expected_logs = [
@@ -192,6 +197,12 @@ class SdkLoggerTest < Minitest::Test
       assert_includes(msg, logged_messages[i])
       i += 1
     end
+    expected_response_headers = {
+      'set-cookies' => 'some value',
+      CONTENT_LENGTH_HEADER => '449',
+      CONTENT_TYPE_HEADER => JSON_CONTENT_TYPE
+    }
+    assert_equal(expected_response_headers, @response.headers)
   end
   def test_end_to_end_with_logger_enabled
     expected_logs = [

--- a/test/test-apimatic-core/logger/sdk_logger_test.rb
+++ b/test/test-apimatic-core/logger/sdk_logger_test.rb
@@ -124,7 +124,7 @@ class SdkLoggerTest < Minitest::Test
   def test_log_req_headers
     expected_logs = [
       @basic_request_log,
-      'info: Request headers {"authorization"=>"**Redacted**", "content-length"=>"449", "content-type"=>"application/json"}',
+      "info: Request headers {\"authorization\"=>\"#{REDACTED}\", \"content-length\"=>\"449\", \"content-type\"=>\"application/json\"}",
     ]
 
     logger = TestLogger.new
@@ -177,7 +177,7 @@ class SdkLoggerTest < Minitest::Test
   def test_log_response_headers
     expected_logs = [
       @basic_response_log,
-      'info: Response headers {"set-cookies"=>"**Redacted**", "content-length"=>"449", "content-type"=>"application/json"}',
+      "info: Response headers {\"set-cookies\"=>\"#{REDACTED}\", \"content-length\"=>\"449\", \"content-type\"=>\"application/json\"}",
     ]
      
     logger = TestLogger.new

--- a/test/test-apimatic-core/utilities/logger_helper_test.rb
+++ b/test/test-apimatic-core/utilities/logger_helper_test.rb
@@ -101,7 +101,7 @@ class LoggerHelperTest < Minitest::Test
 
   def test_masking_sensitive_headers_with_global_mask_sensitive_header_flag_enabled
     headers = { 'Authorization' => TEST_TOKEN, 'XYZ' => 'Testing' }
-    assert_equal({ 'Authorization' => '**Redacted**', 'XYZ' => '**Redacted**' },
+    assert_equal({ 'Authorization' => REDACTED, 'XYZ' => REDACTED },
                  LoggerHelper.apply_masking_to_sensitive_headers(
                    headers, true, []))
   end
@@ -109,7 +109,7 @@ class LoggerHelperTest < Minitest::Test
   def test_masking_sensitive_headers_with_sensitive_header
     headers = { 'Authorization' => TEST_TOKEN, 'XYZ' => 'Testing' }
     headers_to_unmask = ['Authorization']
-    assert_equal({ 'Authorization' => TEST_TOKEN, 'XYZ' => '**Redacted**' },
+    assert_equal({ 'Authorization' => TEST_TOKEN, 'XYZ' => REDACTED },
                  LoggerHelper.apply_masking_to_sensitive_headers(
                    headers, true, headers_to_unmask))
   end
@@ -127,11 +127,11 @@ class LoggerHelperTest < Minitest::Test
   end
 
   def test_mask_if_sensitive_header_with_nil_headers_to_unmask
-    assert_equal '**Redacted**', LoggerHelper.mask_if_sensitive_header('Authorization', TEST_TOKEN, nil)
+    assert_equal REDACTED, LoggerHelper.mask_if_sensitive_header('Authorization', TEST_TOKEN, nil)
   end
 
   def test_sensitive_header_with_empty_headers_to_unmask
-    assert_equal '**Redacted**', LoggerHelper.mask_if_sensitive_header('Authorization', TEST_TOKEN, [])
+    assert_equal REDACTED, LoggerHelper.mask_if_sensitive_header('Authorization', TEST_TOKEN, [])
   end
 
   def test_sensitive_header_with_non_empty_headers_to_unmask

--- a/test/test-helper/mock_helper.rb
+++ b/test/test-helper/mock_helper.rb
@@ -134,7 +134,7 @@ module TestComponent
                          .additional_headers({ "additionalHeader": "value" })
     end
 
-    def self.create_logging_configuration(logger: nil, log_level: nil, request_logging_config: nil, response_logging_config: nil, mask_sensitive_headers: nil)
+    def self.create_logging_configuration(logger: nil, log_level: nil, request_logging_config: nil, response_logging_config: nil, mask_sensitive_headers: true)
       request_logging_config = request_logging_config || MockHelper.create_request_logging_configuration()
       response_logging_config = response_logging_config || MockHelper.create_response_logging_configuration()
       ApiLoggingConfiguration.new(logger, log_level, request_logging_config, response_logging_config, mask_sensitive_headers)


### PR DESCRIPTION




## What
This PR fixes the effect of masking headers flow on the actual request header values. Now the masking headers flow does not affect the actual request header values as the `apply_masking_to_sensitive_headers` is returning a new headers hash instead of mutating the provided one.

## Why
 - To fix the critical bug caused due to the logging feature
 - To keep the request header values same as provided by users.

Closes #40 

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
