### PR TITLE
feat(empty-response): handle empty response in json deserialize

### DIFF
--- a/apimatic_core.gemspec
+++ b/apimatic_core.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'apimatic_core'
-  s.version = '0.3.8'
+  s.version = '0.3.9'
   s.summary = 'A library that contains apimatic-apimatic-core logic and utilities for consuming REST APIs using Python SDKs generated '\
               'by APIMatic.'
   s.description = 'The APIMatic Core libraries provide a stable runtime that powers all the functionality of SDKs.'\

--- a/lib/apimatic-core/response_handler.rb
+++ b/lib/apimatic-core/response_handler.rb
@@ -191,6 +191,8 @@ module CoreLibrary
     # Applies deserializer to the response.
     # @param [Boolean] should_symbolize_hash Flag to symbolize the hash during response deserialization.
     def apply_deserializer(response, should_symbolize_hash)
+      return if response.raw_body.nil? or response.raw_body.to_s.strip.empty?
+
       return apply_xml_deserializer(response) if @is_xml_response
       return response.raw_body if @deserializer.nil?
 

--- a/lib/apimatic-core/response_handler.rb
+++ b/lib/apimatic-core/response_handler.rb
@@ -16,6 +16,7 @@ module CoreLibrary
       @is_date_response = false
       @is_response_array = false
       @is_response_void = false
+      @is_nullable_response = false
     end
 
     # Sets deserializer for the response.
@@ -138,6 +139,14 @@ module CoreLibrary
       @is_response_void = is_response_void
       self
     end
+
+    # Sets the is_nullable_response property.
+    # @param [Boolean] is_nullable_response Flag to return early in case of empty response payload.
+    # @return [ResponseHandler] An updated instance of ResponseHandler.
+    def is_nullable_response(is_nullable_response)
+      @is_nullable_response = is_nullable_response
+      self
+    end
     # rubocop:enable Naming/PredicateName
 
     # Main method to handle the response with all the set properties.
@@ -191,7 +200,7 @@ module CoreLibrary
     # Applies deserializer to the response.
     # @param [Boolean] should_symbolize_hash Flag to symbolize the hash during response deserialization.
     def apply_deserializer(response, should_symbolize_hash)
-      return if response.raw_body.nil? || response.raw_body.to_s.strip.empty?
+      return if @is_nullable_response && (response.raw_body.nil? || response.raw_body.to_s.strip.empty?)
 
       return apply_xml_deserializer(response) if @is_xml_response
       return response.raw_body if @deserializer.nil?

--- a/lib/apimatic-core/response_handler.rb
+++ b/lib/apimatic-core/response_handler.rb
@@ -191,7 +191,7 @@ module CoreLibrary
     # Applies deserializer to the response.
     # @param [Boolean] should_symbolize_hash Flag to symbolize the hash during response deserialization.
     def apply_deserializer(response, should_symbolize_hash)
-      return if response.raw_body.nil? or response.raw_body.to_s.strip.empty?
+      return if response.raw_body.nil? || response.raw_body.to_s.strip.empty?
 
       return apply_xml_deserializer(response) if @is_xml_response
       return response.raw_body if @deserializer.nil?

--- a/lib/apimatic-core/utilities/api_helper.rb
+++ b/lib/apimatic-core/utilities/api_helper.rb
@@ -290,7 +290,7 @@ module CoreLibrary
     # @return [Hash, Array, nil] The parsed JSON object, or nil if the input string is nil.
     # @raise [TypeError] if the server responds with invalid JSON and primitive type parsing is not allowed.
     def self.json_deserialize(json, should_symbolize = false, allow_primitive_type_parsing = false)
-      return if json.nil? or json.to_s.strip.empty?
+      return if json.nil? || json.to_s.strip.empty?
 
       begin
         JSON.parse(json, symbolize_names: should_symbolize)

--- a/lib/apimatic-core/utilities/api_helper.rb
+++ b/lib/apimatic-core/utilities/api_helper.rb
@@ -290,7 +290,7 @@ module CoreLibrary
     # @return [Hash, Array, nil] The parsed JSON object, or nil if the input string is nil.
     # @raise [TypeError] if the server responds with invalid JSON and primitive type parsing is not allowed.
     def self.json_deserialize(json, should_symbolize = false, allow_primitive_type_parsing = false)
-      return if json.nil?
+      return if json.nil? or json.to_s.strip.empty?
 
       begin
         JSON.parse(json, symbolize_names: should_symbolize)

--- a/test/test-apimatic-core/response_handler_test.rb
+++ b/test/test-apimatic-core/response_handler_test.rb
@@ -331,8 +331,10 @@ class ResponseHandlerTest < Minitest::Test
                                          response_body.to_i
                                        end)
                                        .handle(response_mock, MockHelper.get_global_errors)
+    expected_response = 0
 
-    assert_nil actual_response
+    refute_nil actual_response
+    assert_equal expected_response, actual_response
 
     actual_response = @response_handler
                         .deserializer(ApiHelper.method(:custom_type_deserializer))
@@ -351,9 +353,54 @@ class ResponseHandlerTest < Minitest::Test
                                        end)
                                        .handle(response_mock, MockHelper.get_global_errors)
 
+    refute_nil actual_response
+    assert_equal expected_response, actual_response
+
+    actual_response = @response_handler
+                        .deserializer(ApiHelper.method(:custom_type_deserializer))
+                        .deserialize_into(Validate.method(:from_hash))
+                        .handle(response_mock, MockHelper.get_global_errors)
+
+    assert_nil actual_response
+  end
+
+  def test_empty_response_body_with_nullable_response_flag
+    response_body_mock = ''
+    response_mock = MockHelper.create_response status_code: 200,
+                                               raw_body: response_body_mock
+    actual_response = @response_handler.deserializer(ApiHelper.method(:deserialize_primitive_types))
+                                       .is_primitive_response(true)
+                                       .is_nullable_response(true)
+                                       .deserialize_into(proc do |response_body|
+                                         response_body.to_i
+                                       end)
+                                       .handle(response_mock, MockHelper.get_global_errors)
+
     assert_nil actual_response
 
     actual_response = @response_handler
+                        .is_nullable_response(true)
+                        .deserializer(ApiHelper.method(:custom_type_deserializer))
+                        .deserialize_into(Validate.method(:from_hash))
+                        .handle(response_mock, MockHelper.get_global_errors)
+
+    assert_nil actual_response
+
+    response_body_mock = '    '
+    response_mock = MockHelper.create_response status_code: 200,
+                                               raw_body: response_body_mock
+    actual_response = @response_handler.deserializer(ApiHelper.method(:deserialize_primitive_types))
+                                       .is_nullable_response(true)
+                                       .is_primitive_response(true)
+                                       .deserialize_into(proc do |response_body|
+                                         response_body.to_i
+                                       end)
+                                       .handle(response_mock, MockHelper.get_global_errors)
+
+    assert_nil actual_response
+
+    actual_response = @response_handler
+                        .is_nullable_response(true)
                         .deserializer(ApiHelper.method(:custom_type_deserializer))
                         .deserialize_into(Validate.method(:from_hash))
                         .handle(response_mock, MockHelper.get_global_errors)

--- a/test/test-apimatic-core/utilities/api_helper_test.rb
+++ b/test/test-apimatic-core/utilities/api_helper_test.rb
@@ -236,16 +236,18 @@ class ApiHelperTest < Minitest::Test
   end
 
   def test_json_deserialize
-    assert_nil(ApiHelper.json_deserialize(nil, false))
+    assert_nil(ApiHelper.json_deserialize(nil, ))
+    assert_nil(ApiHelper.json_deserialize('', ))
+    assert_nil(ApiHelper.json_deserialize('    ', ))
     assert_equal(ApiHelper.json_deserialize(
       '{"name":"Jone","age":23,"address":"H # 531, S # 20","uid":"1234","birthday":"2016-03-13",'\
-'"birthtime":"2016-03-13T12:52:32.123Z"}',
+        '"birthtime":"2016-03-13T12:52:32.123Z"}',
       false),
                  { "name" => "Jone", "age" => 23, "address" => "H # 531, S # 20", "uid" => "1234",
                    "birthday" => "2016-03-13", "birthtime" => "2016-03-13T12:52:32.123Z" })
     assert_equal(ApiHelper.json_deserialize(
       '{"name":"Jone","age":23,"address":"H # 531, S # 20","uid":"1234",'\
-'"birthday":"2016-03-13","birthtime":"2016-03-13T12:52:32.123Z"}',
+        '"birthday":"2016-03-13","birthtime":"2016-03-13T12:52:32.123Z"}',
       true),
                  { :name => "Jone", :age => 23, :address => "H # 531, S # 20", :uid => "1234",
                    :birthday => "2016-03-13", :birthtime => "2016-03-13T12:52:32.123Z" })


### PR DESCRIPTION




## What
This PR fixes an issue where ApiHelper::json_deserialize and response_handler returned the same empty payload (nil or empty string) or default values in case of scalar types instead of nil when the API response was missing.

The change ensures the utility and response handler behaves as expected and returns nil for empty responses.

## Why
 - To return a proper value (i.e. None) when the response payload is empty.

closes #42

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
