### PR TITLE
fix(void-response): void response handling with complete http response setting

### DIFF
--- a/apimatic_core.gemspec
+++ b/apimatic_core.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'apimatic_core'
-  s.version = '0.3.9'
+  s.version = '0.3.10'
   s.summary = 'A library that contains apimatic-apimatic-core logic and utilities for consuming REST APIs using Python SDKs generated '\
               'by APIMatic.'
   s.description = 'The APIMatic Core libraries provide a stable runtime that powers all the functionality of SDKs.'\

--- a/lib/apimatic-core/response_handler.rb
+++ b/lib/apimatic-core/response_handler.rb
@@ -161,7 +161,7 @@ module CoreLibrary
       # validating response if configured
       validate(response, global_errors)
 
-      return if @is_response_void
+      return if @is_response_void && !@is_api_response
 
       # applying deserializer if configured
       deserialized_value = apply_deserializer(response, should_symbolize_hash)

--- a/test/test-apimatic-core/response_handler_test.rb
+++ b/test/test-apimatic-core/response_handler_test.rb
@@ -293,6 +293,16 @@ class ResponseHandlerTest < Minitest::Test
     assert_nil(actual_response)
   end
 
+
+  def test_void_response_with_api_response
+    response_mock = MockHelper.create_response status_code: 200
+    actual_response = @response_handler.is_response_void(true).is_api_response(true)
+                                       .handle(response_mock, MockHelper.get_global_errors)
+
+    refute_nil(actual_response)
+    assert_equal(200, actual_response.status_code)
+  end
+
   def test_no_deserializer_configured_case
     response_body_mock = 'This is simple response.'
     response_mock = MockHelper.create_response status_code: 200,


### PR DESCRIPTION

## What
This PR ensures that the ResponseHandler returns an ApiResponse object even when the response is void.  Consequently, this addresses the issue where the endpoint receives `nil` instead of an ApiResponse object.

## Why
 - To fix the behavior of void endpoint response when complete http response setting is enabled.

Closes #44

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
