### PR TITLE
ci: update dependencies and supported ruby version

### DIFF
--- a/.github/workflows/lint-runner.yml
+++ b/.github/workflows/lint-runner.yml
@@ -18,7 +18,7 @@ jobs:
     if: "! contains(toJSON(github.event.head_commit.message), 'skip ci')"
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -23,7 +23,7 @@ jobs:
     if: "! contains(toJSON(github.event.head_commit.message), 'skip ci')"
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Core library ruby does the job of congregating common and core functionality fro
 
 
 ## Installation
-You will need `2.6 <= Ruby version <= 3.2` to support this package.
+You will need `2.6 <= Ruby version <= 3.3` to support this package.
 
 Installation is quite simple, just execute the following command:
 ```

--- a/apimatic_core.gemspec
+++ b/apimatic_core.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'apimatic_core'
-  s.version = '0.3.11'
+  s.version = '0.3.12'
   s.summary = 'A library that contains apimatic-apimatic-core logic and utilities for consuming REST APIs using Python SDKs generated '\
               'by APIMatic.'
   s.description = 'The APIMatic Core libraries provide a stable runtime that powers all the functionality of SDKs.'\
@@ -12,13 +12,13 @@ Gem::Specification.new do |s|
   s.homepage = 'https://apimatic.io'
   s.license = 'MIT'
   s.add_dependency('apimatic_core_interfaces', '~> 0.2.0')
-  s.add_dependency('nokogiri', '~> 1.10', '>=1.10.10')
+  s.add_dependency('nokogiri', '~> 1.13', '>=1.13.10')
   s.add_dependency('certifi', '~> 2018.1', '>= 2018.01.18')
   s.add_dependency('faraday-multipart', '~> 1.0')
-  s.add_development_dependency('faraday', '~> 2.0', '>= 2.0.1')
-  s.add_development_dependency('minitest', '~> 5.14', '>= 5.14.1')
+  s.add_development_dependency('faraday', '~> 2.8', '>= 2.8.1')
+  s.add_development_dependency('minitest', '~> 5.25', '>= 5.25.4')
   s.add_development_dependency('minitest-proveit', '~> 1.0')
-  s.add_development_dependency('simplecov', '~> 0.21.2')
+  s.add_development_dependency('simplecov', '~> 0.22.0')
   s.required_ruby_version = ['>= 2.6']
   s.files = Dir['{lib, test}/**/*', 'README*', 'LICENSE*']
   s.require_paths = ['lib']


### PR DESCRIPTION
## What
Update dependencies with max range support from 2.6 to 3.3 and add support for ruby 3.3 version in CI. 

## Why
To update the dependencies to a better supported version

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [x] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [ ] My code follows the coding conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
