### PR TITLE
feat(http-header): add support for complex types

### DIFF
--- a/apimatic_core.gemspec
+++ b/apimatic_core.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'apimatic_core'
-  s.version = '0.3.12'
+  s.version = '0.3.13'
   s.summary = 'A library that contains apimatic-apimatic-core logic and utilities for consuming REST APIs using Python SDKs generated '\
               'by APIMatic.'
   s.description = 'The APIMatic Core libraries provide a stable runtime that powers all the functionality of SDKs.'\

--- a/lib/apimatic-core/request_builder.rb
+++ b/lib/apimatic-core/request_builder.rb
@@ -222,7 +222,11 @@ module CoreLibrary
         _request_headers.merge!(@header_params)
       end
 
-      _request_headers
+      _serialized_headers = _request_headers.transform_values do |value|
+        value.nil? ? value : ApiHelper.json_serialize(value)
+      end
+
+      _serialized_headers
     end
 
     # Processes the body parameter of the request (including form param, json body or xml body).

--- a/lib/apimatic-core/types/sdk/base_model.rb
+++ b/lib/apimatic-core/types/sdk/base_model.rb
@@ -16,7 +16,7 @@ module CoreLibrary
 
     # Override for additional model properties.
     def respond_to_missing?(method_sym, include_private = false)
-      instance_variable_defined?("@#{method_sym}") ? true : super
+      instance_variable_defined?("@#{method_sym}") || super
     end
   end
 end

--- a/test/test-apimatic-core/request_builder_test.rb
+++ b/test/test-apimatic-core/request_builder_test.rb
@@ -160,10 +160,18 @@ class RequestBuilderTest < Minitest::Test
 
   def test_header_param
     actual = MockHelper.create_basic_request_builder
-                       .header_param(MockHelper.new_parameter("value", key: "key"))
+                       .header_param(MockHelper.new_parameter("value", key: "string"))
+                       .header_param(MockHelper.new_parameter(10, key: "number"))
+                       .header_param(MockHelper.new_parameter(MockHelper.get_person_model, key: "model"))
+                       .header_param(MockHelper.new_parameter([1, 2, 3, 4], key: "array"))
+                       .header_param(MockHelper.new_parameter({ key1: 'value1', key2: 'value2' }, key: "hash"))
                        .build({})
 
-    assert(actual.headers["key"] == "value")
+    assert(actual.headers["string"] == "value")
+    assert(actual.headers["model"] == CoreLibrary::ApiHelper.json_serialize(MockHelper.get_person_model))
+    assert(actual.headers["number"] == '10')
+    assert(actual.headers["array"] == '[1,2,3,4]')
+    assert(actual.headers["hash"] == '{"key1":"value1","key2":"value2"}')
   end
 
   def test_form_param
@@ -290,8 +298,17 @@ class RequestBuilderTest < Minitest::Test
     actual = MockHelper.create_basic_request_builder_with_global_headers
                        .build({})
 
-    assert(actual.headers[:globalHeader] == "value")
-    assert(actual.headers[:additionalHeader] == "value")
+    assert(actual.headers[:globalHeaderString] == "value")
+    assert(actual.headers[:globalHeaderModel] == CoreLibrary::ApiHelper.json_serialize(MockHelper.get_person_model))
+    assert(actual.headers[:globalHeaderNumber] == '20')
+    assert(actual.headers[:globalHeaderArray] == '[1,2,3,4]')
+    assert(actual.headers[:globalHeaderHash] == '{"key1":"value1","key2":"value2"}')
+
+    assert(actual.headers[:additionalHeaderString] == "value")
+    assert(actual.headers[:additionalHeaderModel] == CoreLibrary::ApiHelper.json_serialize(MockHelper.get_person_model))
+    assert(actual.headers[:additionalHeaderNumber] == '20')
+    assert(actual.headers[:additionalHeaderArray] == '[1,2,3,4]')
+    assert(actual.headers[:additionalHeaderHash] == '{"key1":"value1","key2":"value2"}')
   end
 
   def test_multipart_param

--- a/test/test-apimatic-core/request_builder_test.rb
+++ b/test/test-apimatic-core/request_builder_test.rb
@@ -163,15 +163,15 @@ class RequestBuilderTest < Minitest::Test
                        .header_param(MockHelper.new_parameter("value", key: "string"))
                        .header_param(MockHelper.new_parameter(10, key: "number"))
                        .header_param(MockHelper.new_parameter(MockHelper.get_person_model, key: "model"))
-                       .header_param(MockHelper.new_parameter([1, 2, 3, 4], key: "array"))
-                       .header_param(MockHelper.new_parameter({ key1: 'value1', key2: 'value2' }, key: "hash"))
+                       .header_param(MockHelper.new_parameter([11, 22, 33, 44], key: "array"))
+                       .header_param(MockHelper.new_parameter({ alpha: 'value', bravo: 'value' }, key: "hash"))
                        .build({})
 
     assert(actual.headers["string"] == "value")
     assert(actual.headers["model"] == CoreLibrary::ApiHelper.json_serialize(MockHelper.get_person_model))
     assert(actual.headers["number"] == '10')
-    assert(actual.headers["array"] == '[1,2,3,4]')
-    assert(actual.headers["hash"] == '{"key1":"value1","key2":"value2"}')
+    assert(actual.headers["array"] == '[11,22,33,44]')
+    assert(actual.headers["hash"] == '{"alpha":"value","bravo":"value"}')
   end
 
   def test_form_param
@@ -307,8 +307,8 @@ class RequestBuilderTest < Minitest::Test
     assert(actual.headers[:additionalHeaderString] == "value")
     assert(actual.headers[:additionalHeaderModel] == CoreLibrary::ApiHelper.json_serialize(MockHelper.get_person_model))
     assert(actual.headers[:additionalHeaderNumber] == '20')
-    assert(actual.headers[:additionalHeaderArray] == '[1,2,3,4]')
-    assert(actual.headers[:additionalHeaderHash] == '{"key1":"value1","key2":"value2"}')
+    assert(actual.headers[:additionalHeaderArray] == '[11,12,13,14]')
+    assert(actual.headers[:additionalHeaderHash] == '{"name":"alice","department":"finance"}')
   end
 
   def test_multipart_param

--- a/test/test-helper/mock_helper.rb
+++ b/test/test-helper/mock_helper.rb
@@ -151,8 +151,8 @@ module TestComponent
                            {
                              "additionalHeaderString": "value",
                              "additionalHeaderNumber": 20,
-                             "additionalHeaderArray": [1, 2, 3, 4],
-                             "additionalHeaderHash": {"key1": "value1", "key2": "value2"},
+                             "additionalHeaderArray": [11, 12, 13, 14],
+                             "additionalHeaderHash": {"name": "alice", "department": "finance"},
                              "additionalHeaderModel": self.get_person_model
                            })
     end

--- a/test/test-helper/mock_helper.rb
+++ b/test/test-helper/mock_helper.rb
@@ -139,8 +139,22 @@ module TestComponent
       GlobalConfiguration.new(client_configuration: create_client_configuration(http_callback: http_callback))
                          .base_uri_executor(method(:get_base_uri))
                          .global_errors(get_global_errors)
-                         .global_headers({ "globalHeader": "value" })
-                         .additional_headers({ "additionalHeader": "value" })
+                         .global_headers(
+                           {
+                             "globalHeaderString": "value",
+                             "globalHeaderNumber": 20,
+                             "globalHeaderArray": [1, 2, 3, 4],
+                             "globalHeaderHash": {"key1": "value1", "key2": "value2"},
+                             "globalHeaderModel": self.get_person_model
+                           })
+                         .additional_headers(
+                           {
+                             "additionalHeaderString": "value",
+                             "additionalHeaderNumber": 20,
+                             "additionalHeaderArray": [1, 2, 3, 4],
+                             "additionalHeaderHash": {"key1": "value1", "key2": "value2"},
+                             "additionalHeaderModel": self.get_person_model
+                           })
     end
 
     def self.create_logging_configuration(logger: nil, log_level: nil, request_logging_config: nil, response_logging_config: nil, mask_sensitive_headers: true)


### PR DESCRIPTION
## What
This PR adds support for processing complex object-typed header parameters in the request builder class. Also, adds unit tests to validate handling of complex header parameters

## Why
To support the custom types like scalar types, non-scalar types and collection of each types.

Closes #58 

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
