### PR TITLE
fix(file-handling): add file rewind and update cache type

### DIFF
--- a/apimatic_core.gemspec
+++ b/apimatic_core.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'apimatic_core'
-  s.version = '0.3.14'
+  s.version = '0.3.15'
   s.summary = 'A library that contains apimatic-apimatic-core logic and utilities for consuming REST APIs using Python SDKs generated '\
               'by APIMatic.'
   s.description = 'The APIMatic Core libraries provide a stable runtime that powers all the functionality of SDKs.'\

--- a/lib/apimatic-core/utilities/file_helper.rb
+++ b/lib/apimatic-core/utilities/file_helper.rb
@@ -9,19 +9,19 @@ module CoreLibrary
     # Class method which takes a URL, downloads the file (if not already downloaded
     # for this test session), and returns the file path.
     # @param [String] url The URL of the required file.
-    # @return [String] The path of the downloaded file.
+    # @return [Tempfile] The path of the downloaded file.
     def self.get_file(url)
-      return @cache[url] if @cache.key?(url)
+      if @cache.key?(url)
+        @cache[url].rewind
+        return @cache[url] if @cache.key?(url)
+      end
 
       tempfile = Tempfile.new('APIMatic')
       tempfile.binmode
       tempfile.write(URI.parse(url).open(ssl_ca_cert: Certifi.where).read)
       tempfile.flush
-      tempfile.close
 
-      raise 'Tempfile path is nil!' if tempfile.path.nil?
-
-      @cache[url] = tempfile.path.to_s # Store only the file path
+      @cache[url] = tempfile
     end
   end
 end

--- a/lib/apimatic-core/utilities/file_helper.rb
+++ b/lib/apimatic-core/utilities/file_helper.rb
@@ -9,11 +9,11 @@ module CoreLibrary
     # Class method which takes a URL, downloads the file (if not already downloaded
     # for this test session), and returns the file path.
     # @param [String] url The URL of the required file.
-    # @return [Tempfile] The path of the downloaded file.
+    # @return [Tempfile] The downloaded file.
     def self.get_file(url)
       if @cache.key?(url)
         @cache[url].rewind
-        return @cache[url] if @cache.key?(url)
+        return @cache[url]
       end
 
       tempfile = Tempfile.new('APIMatic')

--- a/test/test-apimatic-core/utilities/file_helper_test.rb
+++ b/test/test-apimatic-core/utilities/file_helper_test.rb
@@ -21,4 +21,16 @@ class FileHelperTest < Minitest::Test
     end
 
   end
+
+  def test_get_same_file
+    file_url = 'https://gist.githubusercontent.com/asadali214/' \
+      '0a64efec5353d351818475f928c50767/raw/8ad3533799ecb4e01a753aaf04d248e6702d4947/testFile.txt'
+    expected_file_content = 'This test file is created to test CoreFileWrapper functionality'
+
+    File::open(FileHelper.get_file(file_url)) do |actual_file|
+      refute_nil actual_file
+      assert_equal expected_file_content.encode('ascii'), actual_file.read()
+    end
+
+  end
 end


### PR DESCRIPTION


## What
This PR adds the file rewinding and also updates the file cache type as the cache map now stores the Tempfile type which will be returned as is if available. Previously, the file was being closed and was being deleted by garbage collector due to the temporary file.

## Why
 - To fix the failing tests where files are being sent in parallel.

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [ ] My code follows the coding conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
