### PR TITLE
revert: restore `new_builder` method to prevent breaking change

### DIFF
--- a/lib/apimatic-core/api_call.rb
+++ b/lib/apimatic-core/api_call.rb
@@ -3,6 +3,12 @@ module CoreLibrary
   class ApiCall
     attr_reader :request_builder, :pagination_strategy_list, :global_configuration
 
+    # Creates a new builder instance of the API call with pre-configured global and logging configurations.
+    # @return [ApiCall] The instance of ApiCall object.
+    def new_builder
+      ApiCall.new(@global_configuration)
+    end
+    
     # Initializes a new instance of ApiCall.
     # @param [GlobalConfiguration] global_configuration An instance of GlobalConfiguration.
     def initialize(global_configuration)


### PR DESCRIPTION
## What
The `new_builder` method was previously removed as it appeared unused, but its removal caused a breaking change for consumers depending on it. This reverts the change to maintain backward compatibility.

## Why
To provide backward compatibility

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [x] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [ ] My code follows the coding conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
