### PR TITLE
feat(proxy): add ProxySettings model for configuring HTTP proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ gem 'apimatic_core'
 | [`Single`](lib/apimatic-core/authentication/multiple/single_auth.rb)   | Helper class to support single authentication                               |
 
 
-## Configurations
+## Global Configuration
 | Name                                                                                           | Description                                                                     |
 |------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
 | [`GlobalConfiguration`](lib/apimatic-core/configurations/global_configuration.rb )             | Class holding the global configuration properties to make a successful API Call |
@@ -63,10 +63,15 @@ gem 'apimatic_core'
 |-------------------------------------------------------------------------------|------------------------------------------|
 | [`HttpResponseFactory`](lib/apimatic-core/factories/http_response_factory.rb) | Factory class to create an HTTP Response |
 
+## HTTP Configuration
+| Name                                                                                            | Description                                                                                                           |
+|-------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| [`HttpClientConfiguration`](lib/apimatic-core/http/configurations/http_client_configuration.rb) | Class used for configuring SDK by a user                                                                              |
+| [`ProxySettings`](lib/apimatic-core/http/configurations/proxy_settings.rb)                      | ProxySettings encapsulates HTTP proxy configuration for Faraday, e.g. address, port and optional basic authentication |
+
 ## HTTP
 | Name                                                                                            | Description                                                                                                                                                      |
 |-------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [`HttpClientConfiguration`](lib/apimatic-core/http/configurations/http_client_configuration.rb) | Class used for configuring SDK by a user                                                                                                                         |
 | [`HttpRequest`](lib/apimatic-core/http/request/http_request.rb)                                 | Class which contains information about the HTTP Request                                                                                                          |
 | [`ApiResponse`](lib/apimatic-core/http/response/api_response.rb)                                | Wrapper class for Api Response                                                                                                                                   |
 | [`HttpResponse`](lib/apimatic-core/http/response/http_response.rb)                              | Class which contains information about the HTTP Response                                                                                                         |

--- a/apimatic_core.gemspec
+++ b/apimatic_core.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'apimatic_core'
-  s.version = '0.3.17'
+  s.version = '0.3.18'
   s.summary = 'A library that contains apimatic-apimatic-core logic and utilities for consuming REST APIs using Python SDKs generated '\
               'by APIMatic.'
   s.description = 'The APIMatic Core libraries provide a stable runtime that powers all the functionality of SDKs.'\

--- a/apimatic_core.gemspec
+++ b/apimatic_core.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'apimatic_core'
-  s.version = '0.3.18'
+  s.version = '0.3.19'
   s.summary = 'A library that contains apimatic-apimatic-core logic and utilities for consuming REST APIs using Python SDKs generated '\
               'by APIMatic.'
   s.description = 'The APIMatic Core libraries provide a stable runtime that powers all the functionality of SDKs.'\

--- a/lib/apimatic-core/http/configurations/http_client_configuration.rb
+++ b/lib/apimatic-core/http/configurations/http_client_configuration.rb
@@ -16,12 +16,13 @@ module CoreLibrary
     # @param [Boolean] verify Should verification be enabled.
     # @param http_callback A method to be used as http callback
     # @param [HttpClient] http_client An instance of HttpClient
+    # @param [ProxySettings] proxy_settings The configurable settings for proxy
     def initialize(
       connection: nil, adapter: :net_http_persistent, timeout: 60,
       max_retries: 0, retry_interval: 1, backoff_factor: 2,
       retry_statuses: [408, 413, 429, 500, 502, 503, 504, 521, 522, 524],
       retry_methods: %i[get put], cache: false, verify: true, http_callback: nil, http_client: nil,
-      logging_configuration: nil
+      logging_configuration: nil, proxy_settings: nil
     )
       @response_factory = HttpResponseFactory.new
       @connection = connection
@@ -37,6 +38,7 @@ module CoreLibrary
       @cache = cache
       @http_client = http_client
       @logging_configuration = logging_configuration
+      @proxy_settings = proxy_settings
     end
 
     # Setter for http_client.
@@ -58,7 +60,8 @@ module CoreLibrary
         verify: @verify,
         http_callback: http_callback || DeepCloneUtils.deep_copy(@http_callback),
         http_client: DeepCloneUtils.deep_copy(@http_client),
-        logging_configuration: DeepCloneUtils.deep_copy(@logging_configuration)
+        logging_configuration: DeepCloneUtils.deep_copy(@logging_configuration),
+        proxy_settings: DeepCloneUtils.deep_copy(@proxy_settings)
       )
     end
   end

--- a/lib/apimatic-core/http/configurations/proxy_settings.rb
+++ b/lib/apimatic-core/http/configurations/proxy_settings.rb
@@ -8,15 +8,14 @@ module CoreLibrary
 
     ##
     # @param address [String] The proxy server address (e.g., 'http://localhost').
-    # @param port [Integer] The proxy server port (e.g., 8080).
+    # @param port [Integer, nil] Optional proxy server port (e.g., 8080).
     # @param username [String, nil] Optional proxy auth username.
     # @param password [String, nil] Optional proxy auth password.
     #
-    # @raise [ArgumentError] If address or port is invalid.
+    # @raise [ArgumentError] If address is invalid.
     #
-    def initialize(address:, port:, username: nil, password: nil)
+    def initialize(address:, port: nil, username: nil, password: nil)
       raise ArgumentError, 'Proxy address must be a non-empty string' unless address.is_a?(String) && !address.empty?
-      raise ArgumentError, 'Proxy port must be a positive integer' unless port.is_a?(Integer) && port.positive?
 
       @address = address
       @port = port
@@ -30,8 +29,10 @@ module CoreLibrary
     # @return [Hash] A hash with keys :uri, :user, and :password (as applicable).
     #
     def to_hash
+      uri_str = port ? "#{address}:#{port}" : address
+
       {
-        uri: "#{address}:#{port}"
+        uri: uri_str
       }.tap do |hash|
         hash[:user] = username if username
         hash[:password] = password if password

--- a/lib/apimatic-core/http/configurations/proxy_settings.rb
+++ b/lib/apimatic-core/http/configurations/proxy_settings.rb
@@ -1,0 +1,41 @@
+module CoreLibrary
+  ##
+  # ProxySettings encapsulates HTTP proxy configuration for Faraday,
+  # including optional basic authentication.
+  #
+  class ProxySettings
+    attr_accessor :address, :port, :username, :password
+
+    ##
+    # @param address [String] The proxy server address (e.g., 'http://localhost').
+    # @param port [Integer] The proxy server port (e.g., 8080).
+    # @param username [String, nil] Optional proxy auth username.
+    # @param password [String, nil] Optional proxy auth password.
+    #
+    # @raise [ArgumentError] If address or port is invalid.
+    #
+    def initialize(address:, port:, username: nil, password: nil)
+      raise ArgumentError, 'Proxy address must be a non-empty string' unless address.is_a?(String) && !address.empty?
+      raise ArgumentError, 'Proxy port must be a positive integer' unless port.is_a?(Integer) && port.positive?
+
+      @address = address
+      @port = port
+      @username = username
+      @password = password
+    end
+
+    ##
+    # Converts the proxy settings into a Faraday-compatible hash.
+    #
+    # @return [Hash] A hash with keys :uri, :user, and :password (as applicable).
+    #
+    def to_hash
+      {
+        uri: "#{address}:#{port}"
+      }.tap do |hash|
+        hash[:user] = username if username
+        hash[:password] = password if password
+      end
+    end
+  end
+end

--- a/lib/apimatic-core/http/configurations/proxy_settings.rb
+++ b/lib/apimatic-core/http/configurations/proxy_settings.rb
@@ -28,7 +28,7 @@ module CoreLibrary
     #
     # @return [Hash] A hash with keys :uri, :user, and :password (as applicable).
     #
-    def to_hash
+    def to_h
       uri_str = port ? "#{address}:#{port}" : address
 
       {

--- a/lib/apimatic_core.rb
+++ b/lib/apimatic_core.rb
@@ -30,6 +30,7 @@ require_relative 'apimatic-core/pagination/strategies/offset_pagination'
 require_relative 'apimatic-core/pagination/strategies/page_pagination'
 
 require_relative 'apimatic-core/http/configurations/http_client_configuration'
+require_relative 'apimatic-core/http/configurations/proxy_settings'
 require_relative 'apimatic-core/http/request/http_request'
 require_relative 'apimatic-core/http/response/http_response'
 require_relative 'apimatic-core/http/response/api_response'

--- a/test/test-apimatic-core/http/configuration/proxy_settings_test.rb
+++ b/test/test-apimatic-core/http/configuration/proxy_settings_test.rb
@@ -22,23 +22,22 @@ class ProxySettingsTest < Minitest::Test
     )
   end
 
-  def test_to_hash_excludes_optional_fields_when_nil
+  def test_to_hash_excludes_username_and_password_when_nil
     proxy = ProxySettings.new(address: 'http://localhost', port: 8080)
 
     assert_equal({ uri: 'http://localhost:8080' }, proxy.to_hash)
   end
 
-  def test_initialize_raises_for_empty_address
-    error = assert_raises(ArgumentError) do
-      ProxySettings.new(address: '', port: 8080)
-    end
-    assert_match(/address must be a non-empty string/, error.message)
+  def test_to_hash_excludes_port_when_nil
+    proxy = ProxySettings.new(address: 'http://localhost')
+
+    assert_equal({ uri: 'http://localhost' }, proxy.to_hash)
   end
 
-  def test_initialize_raises_for_non_positive_port
+  def test_initialize_raises_for_empty_address
     error = assert_raises(ArgumentError) do
-      ProxySettings.new(address: 'http://localhost', port: 0)
+      ProxySettings.new(address: '')
     end
-    assert_match(/port must be a positive integer/, error.message)
+    assert_match(/address must be a non-empty string/, error.message)
   end
 end

--- a/test/test-apimatic-core/http/configuration/proxy_settings_test.rb
+++ b/test/test-apimatic-core/http/configuration/proxy_settings_test.rb
@@ -18,20 +18,20 @@ class ProxySettingsTest < Minitest::Test
         user: 'user',
         password: 'pass'
       },
-      proxy.to_hash
+      proxy.to_h
     )
   end
 
   def test_to_hash_excludes_username_and_password_when_nil
     proxy = ProxySettings.new(address: 'http://localhost', port: 8080)
 
-    assert_equal({ uri: 'http://localhost:8080' }, proxy.to_hash)
+    assert_equal({ uri: 'http://localhost:8080' }, proxy.to_h)
   end
 
   def test_to_hash_excludes_port_when_nil
     proxy = ProxySettings.new(address: 'http://localhost')
 
-    assert_equal({ uri: 'http://localhost' }, proxy.to_hash)
+    assert_equal({ uri: 'http://localhost' }, proxy.to_h)
   end
 
   def test_initialize_raises_for_empty_address

--- a/test/test-apimatic-core/http/configuration/proxy_settings_test.rb
+++ b/test/test-apimatic-core/http/configuration/proxy_settings_test.rb
@@ -1,0 +1,44 @@
+require 'minitest/autorun'
+require 'apimatic_core'
+
+class ProxySettingsTest < Minitest::Test
+  include CoreLibrary
+
+  def test_to_hash_includes_all_fields
+    proxy = ProxySettings.new(
+      address: 'http://localhost',
+      port: 8080,
+      username: 'user',
+      password: 'pass'
+    )
+
+    assert_equal(
+      {
+        uri: 'http://localhost:8080',
+        user: 'user',
+        password: 'pass'
+      },
+      proxy.to_hash
+    )
+  end
+
+  def test_to_hash_excludes_optional_fields_when_nil
+    proxy = ProxySettings.new(address: 'http://localhost', port: 8080)
+
+    assert_equal({ uri: 'http://localhost:8080' }, proxy.to_hash)
+  end
+
+  def test_initialize_raises_for_empty_address
+    error = assert_raises(ArgumentError) do
+      ProxySettings.new(address: '', port: 8080)
+    end
+    assert_match(/address must be a non-empty string/, error.message)
+  end
+
+  def test_initialize_raises_for_non_positive_port
+    error = assert_raises(ArgumentError) do
+      ProxySettings.new(address: 'http://localhost', port: 0)
+    end
+    assert_match(/port must be a positive integer/, error.message)
+  end
+end


### PR DESCRIPTION
## What

Introduces a structured ProxySettings model with address, port, optional username, and password. Includes a `to_hash` method for Faraday integration, along with validations and documentation.

## Why
To support the data model for proxy settings to be shared via http client configuration

Closes #69 

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
