### PR TITLE
fix(deserialization): handle non-JSON responses in dynamic deserialization

### DIFF
--- a/apimatic_core.gemspec
+++ b/apimatic_core.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'apimatic_core'
-  s.version = '0.3.17'
+  s.version = '0.3.18'
   s.summary = 'A library that contains apimatic-apimatic-core logic and utilities for consuming REST APIs using Python SDKs generated '\
               'by APIMatic.'
   s.description = 'The APIMatic Core libraries provide a stable runtime that powers all the functionality of SDKs.'\

--- a/lib/apimatic-core/utilities/api_helper.rb
+++ b/lib/apimatic-core/utilities/api_helper.rb
@@ -73,7 +73,8 @@ module CoreLibrary
     # Deserializer to use when the type of response is not known beforehand.
     # @param response The response received.
     def self.dynamic_deserializer(response, should_symbolize)
-      json_deserialize(response, should_symbolize) unless response.nil? || response.to_s.strip.empty?
+      json_deserialize(response, should_symbolize) unless response.nil? ||
+        response.to_s.strip.empty? || !deserializable_json?(response)
     end
 
     # Deserializes response to a known custom model type.
@@ -300,6 +301,20 @@ module CoreLibrary
         raise TypeError, 'Server responded with invalid JSON.' unless allow_primitive_type_parsing
 
         ApiHelper.apply_primitive_type_parser(json)
+      end
+    end
+
+    # Checks whether the content is deserializable JSON.
+    # @param [String] json A JSON string.
+    # @return [Boolean] True if the content can be deserialized, false otherwise.
+    def self.deserializable_json?(json)
+      return false if json.nil? || json.to_s.strip.empty?
+
+      begin
+        JSON.parse(json)
+        true
+      rescue JSON::ParserError
+        false
       end
     end
 

--- a/lib/apimatic-core/utilities/api_helper.rb
+++ b/lib/apimatic-core/utilities/api_helper.rb
@@ -73,8 +73,9 @@ module CoreLibrary
     # Deserializer to use when the type of response is not known beforehand.
     # @param response The response received.
     def self.dynamic_deserializer(response, should_symbolize)
-      json_deserialize(response, should_symbolize) unless
-        response.nil? || response.to_s.strip.empty? || !deserializable_json?(response)
+      return unless deserializable_json?(response)
+
+      json_deserialize(response, should_symbolize)
     end
 
     # Deserializes response to a known custom model type.

--- a/lib/apimatic-core/utilities/api_helper.rb
+++ b/lib/apimatic-core/utilities/api_helper.rb
@@ -72,6 +72,7 @@ module CoreLibrary
 
     # Deserializer to use when the type of response is not known beforehand.
     # @param response The response received.
+    # @return [Hash, Array, nil] The deserialized response.
     def self.dynamic_deserializer(response, should_symbolize)
       return unless deserializable_json?(response)
 

--- a/lib/apimatic-core/utilities/api_helper.rb
+++ b/lib/apimatic-core/utilities/api_helper.rb
@@ -73,8 +73,8 @@ module CoreLibrary
     # Deserializer to use when the type of response is not known beforehand.
     # @param response The response received.
     def self.dynamic_deserializer(response, should_symbolize)
-      json_deserialize(response, should_symbolize) unless response.nil? ||
-        response.to_s.strip.empty? || !deserializable_json?(response)
+      json_deserialize(response, should_symbolize) unless
+        response.nil? || response.to_s.strip.empty? || !deserializable_json?(response)
     end
 
     # Deserializes response to a known custom model type.

--- a/test/test-apimatic-core/utilities/api_helper_test.rb
+++ b/test/test-apimatic-core/utilities/api_helper_test.rb
@@ -833,4 +833,32 @@ class ApiHelperTest < Minitest::Test
     # Restore original method to avoid side effects
     URI.singleton_class.define_method(:parse, original_method)
   end
+
+  def test_deserializable_json
+    valid_cases = {
+      'valid JSON object' => '{"key": "value"}',
+      'valid JSON array' => '[1, 2, 3]',
+      'valid JSON string' => '"hello world"',
+      'valid JSON number' => '42',
+      'valid JSON boolean true' => 'true',
+      'valid JSON boolean false' => 'false',
+      'valid JSON null' => 'null'
+    }
+
+    invalid_cases = {
+      'invalid JSON - unquoted value' => '{"key": value}',
+      'invalid JSON - trailing comma' => '{"key": "value",}',
+      'empty string' => '',
+      'nil input' => nil,
+      'whitespace only' => '   '
+    }
+
+    valid_cases.each do |desc, input|
+      assert ApiHelper.deserializable_json?(input), "Expected valid JSON for: #{desc}"
+    end
+
+    invalid_cases.each do |desc, input|
+      refute ApiHelper.deserializable_json?(input), "Expected invalid JSON for: #{desc}"
+    end
+  end
 end


### PR DESCRIPTION
## What
This PR wraps JSON parsing with a `json_deserializable?` check to prevent errors when the response body is not valid JSON (e.g., plain text, HTML, or image). If deserialization fails, return the raw response body instead of raising an exception.

## Why
 - To make the library stable for the dynamic type handling

Closes #72 

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
