### PR TITLE
feat(proxy_settings): add from_hash method for proxy_settings

### DIFF
--- a/apimatic_core.gemspec
+++ b/apimatic_core.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'apimatic_core'
-  s.version = '0.3.20'
+  s.version = '0.3.21'
   s.summary = 'A library that contains apimatic-apimatic-core logic and utilities for consuming REST APIs using Python SDKs generated '\
               'by APIMatic.'
   s.description = 'The APIMatic Core libraries provide a stable runtime that powers all the functionality of SDKs.'\

--- a/apimatic_core.gemspec
+++ b/apimatic_core.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name = 'apimatic_core'
   s.version = '0.3.21'
-  s.summary = 'A library that contains apimatic-apimatic-core logic and utilities for consuming REST APIs using Python SDKs generated '\
+  s.summary = 'A library that contains apimatic-core logic and utilities for consuming REST APIs using Ruby SDKs generated '\
               'by APIMatic.'
   s.description = 'The APIMatic Core libraries provide a stable runtime that powers all the functionality of SDKs.'\
                   ' This includes functionality like the ability to create HTTP requests, handle responses, apply '\

--- a/lib/apimatic-core/http/configurations/proxy_settings.rb
+++ b/lib/apimatic-core/http/configurations/proxy_settings.rb
@@ -38,5 +38,25 @@ module CoreLibrary
         hash[:password] = password if password
       end
     end
+
+    ##
+    # Creates a ProxySettings instance from a hash.
+    #
+    # @param hash [Hash] A hash containing :address, :port, :username, and/or :password.
+    # @return [ProxySettings, nil] Returns a new instance or nil if hash is nil/empty.
+    #
+    def self.from_hash(hash)
+      return nil if hash.nil? || hash.empty?
+
+      # Support both symbol and string keys
+      address = hash[:address] || hash['address']
+      port = hash[:port] || hash['port']
+      username = hash[:username] || hash['username']
+      password = hash[:password] || hash['password']
+
+      return nil if address.nil? || address.strip.empty?
+
+      new(address: address, port: port, username: username, password: password)
+    end
   end
 end

--- a/test/test-apimatic-core/http/configuration/proxy_settings_test.rb
+++ b/test/test-apimatic-core/http/configuration/proxy_settings_test.rb
@@ -4,6 +4,9 @@ require 'apimatic_core'
 class ProxySettingsTest < Minitest::Test
   include CoreLibrary
 
+  # -------------------------------
+  # Tests for ProxySettings.to_h
+  # -------------------------------
   def test_to_hash_includes_all_fields
     proxy = ProxySettings.new(
       address: 'http://localhost',
@@ -39,5 +42,59 @@ class ProxySettingsTest < Minitest::Test
       ProxySettings.new(address: '')
     end
     assert_match(/address must be a non-empty string/, error.message)
+  end
+
+  # -------------------------------
+  # Tests for ProxySettings.from_hash
+  # -------------------------------
+
+  def test_from_hash_creates_instance_with_all_fields
+    hash = {
+      address: 'http://proxy.local',
+      port: 3128,
+      username: 'user',
+      password: 'pass'
+    }
+
+    proxy = ProxySettings.from_hash(hash)
+    refute_nil proxy
+    assert_equal 'http://proxy.local', proxy.address
+    assert_equal 3128, proxy.port
+    assert_equal 'user', proxy.username
+    assert_equal 'pass', proxy.password
+  end
+
+  def test_from_hash_supports_string_keys
+    hash = {
+      'address' => 'http://proxy.example',
+      'port' => 8080,
+      'username' => 'bob',
+      'password' => 'secret'
+    }
+
+    proxy = ProxySettings.from_hash(hash)
+    refute_nil proxy
+    assert_equal 'http://proxy.example', proxy.address
+    assert_equal 8080, proxy.port
+    assert_equal 'bob', proxy.username
+    assert_equal 'secret', proxy.password
+  end
+
+  def test_from_hash_returns_nil_for_nil_input
+    assert_nil ProxySettings.from_hash(nil)
+  end
+
+  def test_from_hash_returns_nil_for_empty_hash
+    assert_nil ProxySettings.from_hash({})
+  end
+
+  def test_from_hash_returns_nil_when_address_is_missing
+    hash = { port: 8080, username: 'x', password: 'y' }
+    assert_nil ProxySettings.from_hash(hash)
+  end
+
+  def test_from_hash_returns_nil_when_address_is_empty_string
+    hash = { address: '', port: 8080 }
+    assert_nil ProxySettings.from_hash(hash)
   end
 end


### PR DESCRIPTION
## What
Add from_string method for proxy_settings

## Why
To consume it in from_env method in client

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
